### PR TITLE
make trace explorer content width responsive

### DIFF
--- a/js/src/TraceExplorer.tsx
+++ b/js/src/TraceExplorer.tsx
@@ -10,7 +10,7 @@ export class TraceExplorer extends DOMWidgetView {
 
   public initialize() {
     this.element = document.createElement('div') as HTMLElement;
-    this.element.style.width = '100%';
+    this.element.style.width = 'auto';
     this.element.style.height = '1400px';
     this.el.appendChild(this.element);
 

--- a/js/src/trace-explorer/App.jsx
+++ b/js/src/trace-explorer/App.jsx
@@ -26,7 +26,7 @@ SOFTWARE.
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import ControlPanel, { width as CONTROLS_WIDTH } from './ControlPanel';
+import ControlPanel from './ControlPanel';
 import Visualization, {
   margin as VIS_MARGIN
 } from '@data-ui/event-flow/src/components/Visualization';
@@ -83,7 +83,7 @@ class App extends React.PureComponent {
       initialMinEventCount: minEventCount
     } = props;
 
-    const visualizationWidth = this.getVisualizationWidth(width, showControls);
+    const visualizationWidth = width;
     const alignByEventType = ANY_EVENT_TYPE;
     const alignByIndex = 1;
     const hiddenEventTypes = {};
@@ -129,11 +129,8 @@ class App extends React.PureComponent {
       this.props.height !== nextProps.height ||
       nextState.graph
     ) {
-      const { showControls, graph, scales: prevScales } = this.state;
-      nextState.visualizationWidth = this.getVisualizationWidth(
-        nextProps.width,
-        showControls
-      );
+      const { graph, scales: prevScales } = this.state;
+      nextState.visualizationWidth = this.state.visualizationWidth;
       nextState.scales = this.getScales(
         nextState.graph || graph,
         nextState.visualizationWidth,
@@ -148,10 +145,6 @@ class App extends React.PureComponent {
       nextState.selectedNode = null;
       this.setState(nextState);
     }
-  }
-
-  getVisualizationWidth(width, showControls) {
-    return width - (showControls ? CONTROLS_WIDTH + VIS_MARGIN.right : 0);
   }
 
   getGraph({
@@ -188,10 +181,10 @@ class App extends React.PureComponent {
   }
 
   handleToggleShowControls() {
-    const { width, height } = this.props;
+    const { height } = this.props;
     const { showControls: prevShowControls, graph } = this.state;
     const showControls = !prevShowControls;
-    const visualizationWidth = this.getVisualizationWidth(width, showControls);
+    const visualizationWidth = this.state.visualizationWidth;
 
     this.setState({
       visualizationWidth,

--- a/js/src/trace-explorer/ControlPanel.jsx
+++ b/js/src/trace-explorer/ControlPanel.jsx
@@ -67,11 +67,10 @@ const styles = StyleSheet.create({
 
   innerContainer: {
     overflowY: 'auto',
-    height: 'inherit',
+    height: 'auto',
     display: 'grid',
     gridTemplateColumns: '30% 65% !important',
     gridColumnGap: '5%',
-    height: '400px !important',
     padding: '1%',
     paddingRight: '2%',
     borderRadius: '10px',
@@ -94,7 +93,6 @@ const styles = StyleSheet.create({
     paddingLeft: 0,
     fontWeight: 700,
     flexGrow: 1,
-    paddingLeft: 0,
     float: 'right',
     width: '70% !important'
   },

--- a/js/src/trace-explorer/ControlPanel.jsx
+++ b/js/src/trace-explorer/ControlPanel.jsx
@@ -69,7 +69,7 @@ const styles = StyleSheet.create({
     overflowY: 'auto',
     height: 'auto',
     display: 'grid',
-    gridTemplateColumns: '30% 65% !important',
+    gridTemplateColumns: '40% 55% !important',
     gridColumnGap: '5%',
     padding: '1%',
     paddingRight: '2%',

--- a/js/src/trace-explorer/ControlPanel.jsx
+++ b/js/src/trace-explorer/ControlPanel.jsx
@@ -94,7 +94,7 @@ const styles = StyleSheet.create({
     fontWeight: 700,
     flexGrow: 1,
     float: 'right',
-    width: '70% !important'
+    width: '60% !important'
   },
 
   header: {

--- a/js/src/trace-explorer/EventFlowComponent.tsx
+++ b/js/src/trace-explorer/EventFlowComponent.tsx
@@ -1,10 +1,10 @@
-import { withScreenSize } from '@vx/responsive';
+import { withParentSize } from '@vx/responsive';
 import React from 'react';
 import { default as App } from './App';
 
-const ResponsiveVis = withScreenSize(
-  ({ screenWidth, screenHeight, ...rest }) => (
-    <App width={985.469} height={900} initialMinEventCount={2} {...rest} />
+const ResponsiveVis = withParentSize(
+  ({ parentWidth, parentHeight, ...rest }) => (
+    <App width={parentWidth} height={900} initialMinEventCount={2} {...rest} />
   )
 );
 

--- a/js/src/trace-explorer/EventFlowComponent.tsx
+++ b/js/src/trace-explorer/EventFlowComponent.tsx
@@ -4,7 +4,7 @@ import { default as App } from './App';
 
 const ResponsiveVis = withScreenSize(
   ({ screenWidth, screenHeight, ...rest }) => (
-    <App width={1200} height={900} initialMinEventCount={2} {...rest} />
+    <App width={985.469} height={900} initialMinEventCount={2} {...rest} />
   )
 );
 

--- a/js/src/trace-explorer/controlpanel.css
+++ b/js/src/trace-explorer/controlpanel.css
@@ -23,7 +23,7 @@ h1 {
   background-color: #fff;
   border-color: #d9d9d9 #ccc #b3b3b3;
   border-radius: 4px;
-  border: 1px solid #ccc;
+  border: 1px solid;
   color: #333;
   cursor: default;
   display: table;
@@ -64,7 +64,7 @@ h1 {
   line-height: 34px;
   padding-left: 10px;
   padding-right: 10px;
-  position: absolute;
+  position: absolute !important;
   right: 0;
   top: 0;
   overflow: hidden;
@@ -148,6 +148,61 @@ h1 {
   box-sizing: border-box;
   background-color: rgba(0, 126, 255, 0.08);
   color: #333;
+}
+
+.Select-option.is-focused {
+  user-select: text;
+  font-family: BlinkMacSystemFont, Roboto, Helvetica Neue, sans-serif !important;
+  font-size: 12px !important;
+  -webkit-box-direction: normal !important;
+  font-weight: 700 !important;
+  cursor: pointer;
+  display: block;
+  padding: 8px 10px;
+  box-sizing: border-box;
+  background-color: rgba(0, 126, 255, 0.08);
+  color: #333;
+}
+
+.Select-option.is-selected.is-focused {
+  user-select: text;
+  font-family: BlinkMacSystemFont, Roboto, Helvetica Neue, sans-serif !important;
+  font-size: 12px !important;
+  -webkit-box-direction: normal !important;
+  font-weight: 700 !important;
+  cursor: pointer;
+  display: block;
+  padding: 8px 10px;
+  box-sizing: border-box;
+  background-color: rgba(0, 126, 255, 0.08);
+  color: #333;
+}
+
+.Select-option {
+  user-select: text;
+  font-family: BlinkMacSystemFont, Roboto, Helvetica Neue, sans-serif !important;
+  font-size: 12px !important;
+  -webkit-box-direction: normal !important;
+  font-weight: 700 !important;
+  cursor: pointer;
+  display: block;
+  padding: 8px;
+  box-sizing: border-box;
+  color: #333;
+}
+
+.Select-option.is-selected {
+  user-select: text;
+  font-family: BlinkMacSystemFont, Roboto, Helvetica Neue, sans-serif !important;
+  font-size: 12px !important;
+  -webkit-box-direction: normal !important;
+  font-weight: 700 !important;
+  cursor: pointer;
+  display: block;
+  padding: 8px;
+  box-sizing: border-box;
+  color: #333;
+  background-color: rgba(0, 126, 255, 0.03);
 }
 
 .vx-legend {

--- a/js/src/trace-explorer/controlpanel.css
+++ b/js/src/trace-explorer/controlpanel.css
@@ -47,6 +47,7 @@ h1 {
   border-spacing: 0;
   border-collapse: separate;
   box-sizing: border-box;
+  width: 0;
 }
 .Select-value {
   user-select: text;
@@ -102,7 +103,7 @@ h1 {
   position: relative;
   text-align: right;
   vertical-align: middle;
-  width: 10vw;
+  width: 100%;
   box-sizing: border-box;
   padding-right: 5px;
 }

--- a/js/src/trace-explorer/controlpanel.css
+++ b/js/src/trace-explorer/controlpanel.css
@@ -187,7 +187,7 @@ h1 {
   font-weight: 700 !important;
   cursor: pointer;
   display: block;
-  padding: 8px;
+  padding: 8px 10px;
   box-sizing: border-box;
   color: #333;
 }
@@ -200,7 +200,7 @@ h1 {
   font-weight: 700 !important;
   cursor: pointer;
   display: block;
-  padding: 8px;
+  padding: 8px 10px;
   box-sizing: border-box;
   color: #333;
   background-color: rgba(0, 126, 255, 0.03);


### PR DESCRIPTION
It used to depend on whether the control panel was showing.
As we have implemented our own setup with the control panel underneath,
the variable content width is no longer needed.